### PR TITLE
Small fix for MatchFilter frequencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,11 @@ __pycache__/
 *.egg
 *.egg-info
 *.swp
+build/*
+build
 dist/*
 dist
 .idea/
+.vscode/
 tests/words.db
 

--- a/pywords/matchfilter.py
+++ b/pywords/matchfilter.py
@@ -195,7 +195,7 @@ class MatchFilter:
             if entry.pos not in self.parts_of_speech:
                 return False
         if self.frequencies:
-            if entry.frequency not in self.frequencies:
+            if entry.freq not in self.frequencies:
                 return False
         if self.ages:
             if entry.age not in self.ages:


### PR DESCRIPTION
This wasn't working for me, until I applied a tiny modification, and now it is!

```python
from pywords.matchfilter import MatchFilter
import pywords.utils as pwutils

s = """
    Hoc cogmine appellare liceat illam maxime memorabilem seriem,
    qua vir acutissimi ingenii Lambertus radices aequationum trinomialium
    primus exprimere docuit in horto.
"""

nouns, _ = pwutils.get_vocab_list(
    s,
    filt=MatchFilter(
        parts_of_speech=["V"],
        frequencies=["A", "C"],
    ),
)
```

It fixes this exception:

```bash
File "/Users/joshua/Projects/AnkiGen/.env/lib/python3.11/site-packages/pywords/matchfilter.py", line 198, in check_dictline_word
    if entry.frequency not in self.frequencies:
       ^^^^^^^^^^^^^^^
AttributeError: 'DictlineNounEntry' object has no attribute 'frequency'. Did you mean: 'get_frequency'?
```

I also added something to .gitignore, just because. Thank you!